### PR TITLE
chore: refactor services to eliminate code duplication

### DIFF
--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -9,7 +9,7 @@ fof-geoip:
       service_ipstack_description: Use <b>https://ipstack.com</b> to make up to 10,000 lookups per month for free. Paid plans include connection info (ISP, organization) and threat level.
 
       service_ipdata_label: IPData
-      service_ipdata_description: Use <b>https://ipdata.co</b> to make up to 1,500 lookups daily for free.
+      service_ipdata_description: Use <b>https://ipdata.co</b> to make up to 1,500 lookups daily for free. Paid plans for higher usage limits are also available.
 
       service_ipapi_label: IP Api
       service_ipapi_description: Use <b>http://ip-api.com</b> to make up to 45 lookups per minute for free. If you make more, your IP may get blacklisted, after which you can unban it at <b>http://ip-api.com/docs/unban</b>.

--- a/src/Api/GeoIP.php
+++ b/src/Api/GeoIP.php
@@ -14,9 +14,12 @@ namespace FoF\GeoIP\Api;
 use Carbon\Carbon;
 use Flarum\Settings\SettingsRepositoryInterface;
 use FoF\GeoIP\IPInfo;
+use FoF\GeoIP\Traits\HandlesGeoIPErrors;
 
 class GeoIP
 {
+    use HandlesGeoIPErrors;
+    
     public static $services = [
         'ipapi'      => Services\IPApi::class,
         'ipdata'     => Services\IPData::class,
@@ -26,14 +29,8 @@ class GeoIP
 
     private $prefix = 'fof-geoip.services';
 
-    /**
-     * @var SettingsRepositoryInterface
-     */
-    private $settings;
-
-    public function __construct(SettingsRepositoryInterface $settings)
+    public function __construct(protected SettingsRepositoryInterface $settings)
     {
-        $this->settings = $settings;
     }
 
     /**
@@ -82,7 +79,7 @@ class GeoIP
         $lastErrorTime = $this->settings->get($timeKey);
 
         if ($lastErrorTime && Carbon::createFromTimestamp($lastErrorTime)->isAfter(Carbon::now()->subHour())) {
-            return self::getFakeResponse($this->settings->get($errorKey));
+            return $this->handleGeoIPError($this->settings->get($errorKey));
         } elseif ($lastErrorTime) {
             $this->settings->delete($timeKey);
             $this->settings->delete($errorKey);

--- a/src/Api/GeoIP.php
+++ b/src/Api/GeoIP.php
@@ -19,7 +19,7 @@ use FoF\GeoIP\Traits\HandlesGeoIPErrors;
 class GeoIP
 {
     use HandlesGeoIPErrors;
-    
+
     public static $services = [
         'ipapi'      => Services\IPApi::class,
         'ipdata'     => Services\IPData::class,

--- a/src/Api/Services/BaseGeoService.php
+++ b/src/Api/Services/BaseGeoService.php
@@ -31,7 +31,7 @@ abstract class BaseGeoService implements ServiceInterface
     {
         $this->client = new Client([
             'base_uri' => $this->host,
-            'verify' => false,
+            'verify'   => false,
         ]);
     }
 
@@ -41,6 +41,7 @@ abstract class BaseGeoService implements ServiceInterface
 
         if ($this->requiresApiKey() && !$apiKey) {
             $this->logger->error("No API key found for {$this->host}");
+
             return null;
         }
 
@@ -51,6 +52,7 @@ abstract class BaseGeoService implements ServiceInterface
 
         if ($this->hasError($body)) {
             $this->logger->error("Error detected in response from {$this->host}");
+
             return $this->handleError($body);
         }
 

--- a/src/Api/Services/BaseGeoService.php
+++ b/src/Api/Services/BaseGeoService.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of fof/geoip.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\GeoIP\Api\Services;
+
+use Flarum\Settings\SettingsRepositoryInterface;
+use FoF\GeoIP\Api\ServiceInterface;
+use FoF\GeoIP\Api\ServiceResponse;
+use GuzzleHttp\Client;
+use Psr\Log\LoggerInterface;
+
+abstract class BaseGeoService implements ServiceInterface
+{
+    /**
+     * @var Client
+     */
+    protected $client;
+
+    protected $host;
+    protected $settingPrefix;
+
+    public function __construct(protected SettingsRepositoryInterface $settings, protected LoggerInterface $logger)
+    {
+        $this->client = new Client([
+            'base_uri' => $this->host,
+            'verify' => false,
+        ]);
+    }
+
+    public function get(string $ip): ?ServiceResponse
+    {
+        $apiKey = $this->settings->get("{$this->settingPrefix}.access_key");
+
+        if ($this->requiresApiKey() && !$apiKey) {
+            $this->logger->error("No API key found for {$this->host}");
+            return null;
+        }
+
+        $res = $this->client->get($this->buildUrl($ip, $apiKey), $this->getRequestOptions($apiKey));
+
+        $body = json_decode($res->getBody());
+        $body = json_decode($res->getBody());
+
+        if ($this->hasError($body)) {
+            $this->logger->error("Error detected in response from {$this->host}");
+            return $this->handleError($body);
+        }
+
+        $data = $this->parseResponse($body);
+
+        return $data;
+    }
+
+    protected function requiresApiKey(): bool
+    {
+        return true;
+    }
+
+    abstract protected function buildUrl(string $ip, ?string $apiKey): string;
+
+    abstract protected function getRequestOptions(?string $apiKey): array;
+
+    abstract protected function hasError(object $body): bool;
+
+    abstract protected function handleError(object $body): ?ServiceResponse;
+
+    abstract protected function parseResponse(object $body): ServiceResponse;
+}

--- a/src/Api/Services/BaseGeoService.php
+++ b/src/Api/Services/BaseGeoService.php
@@ -48,7 +48,6 @@ abstract class BaseGeoService implements ServiceInterface
         $res = $this->client->get($this->buildUrl($ip, $apiKey), $this->getRequestOptions($apiKey));
 
         $body = json_decode($res->getBody());
-        $body = json_decode($res->getBody());
 
         if ($this->hasError($body)) {
             $this->logger->error("Error detected in response from {$this->host}");

--- a/src/Api/Services/IPApi.php
+++ b/src/Api/Services/IPApi.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/geoip.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\GeoIP\Api\Services;
 
 use FoF\GeoIP\Api\GeoIP;
@@ -24,11 +33,11 @@ class IPApi extends BaseGeoService
     {
         return [
             'http_errors' => false,
-            'delay' => 100,
-            'retries' => 3,
-            'query' => [
+            'delay'       => 100,
+            'retries'     => 3,
+            'query'       => [
                 'fields' => 'status,message,countryCode,zip,isp,org',
-            ]
+            ],
         ];
     }
 

--- a/src/Api/Services/IPApi.php
+++ b/src/Api/Services/IPApi.php
@@ -1,63 +1,49 @@
 <?php
 
-/*
- * This file is part of fof/geoip.
- *
- * Copyright (c) FriendsOfFlarum.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace FoF\GeoIP\Api\Services;
 
-use Flarum\Settings\SettingsRepositoryInterface;
-use FoF\GeoIP\Api\ServiceInterface;
+use FoF\GeoIP\Api\GeoIP;
 use FoF\GeoIP\Api\ServiceResponse;
-use GuzzleHttp\Client;
 
-class IPApi implements ServiceInterface
+class IPApi extends BaseGeoService
 {
-    /**
-     * @var SettingsRepositoryInterface
-     */
-    protected $settings;
+    protected $host = 'http://ip-api.com';
+    protected $settingPrefix = 'fof-geoip.services.ipapi';
 
-    /**
-     * @var Client
-     */
-    private $client;
-
-    public function __construct(SettingsRepositoryInterface $settings)
+    protected function buildUrl(string $ip, ?string $apiKey): string
     {
-        $this->settings = $settings;
-
-        $this->client = new Client([
-            'base_uri' => 'http://ip-api.com',
-        ]);
+        return "/json/{$ip}";
     }
 
-    /**
-     * @param string $ip
-     *
-     * @return ServiceResponse|null
-     */
-    public function get(string $ip)
+    protected function requiresApiKey(): bool
     {
-        $res = $this->client->get(
-            "/json/{$ip}",
-            ['query' => [
+        return false;
+    }
+
+    protected function getRequestOptions(?string $apiKey): array
+    {
+        return [
+            'http_errors' => false,
+            'delay' => 100,
+            'retries' => 3,
+            'query' => [
                 'fields' => 'status,message,countryCode,zip,isp,org',
-            ]]
-        );
+            ]
+        ];
+    }
 
-        $body = json_decode($res->getBody());
+    protected function hasError(object $body): bool
+    {
+        return $body->status !== 'success';
+    }
 
-        if ($body->status != 'success') {
-            return (new ServiceResponse())
-                ->setError($body->message);
-        }
+    protected function handleError(object $body): ?ServiceResponse
+    {
+        return GeoIP::setError('ipapi', $body->message ?? json_encode($body));
+    }
 
+    protected function parseResponse(object $body): ServiceResponse
+    {
         return (new ServiceResponse())
             ->setCountryCode($body->countryCode)
             ->setZipCode($body->zip)

--- a/src/Api/Services/IPData.php
+++ b/src/Api/Services/IPData.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of fof/geoip.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace FoF\GeoIP\Api\Services;
 
 use FoF\GeoIP\Api\GeoIP;
@@ -19,12 +28,12 @@ class IPData extends BaseGeoService
     {
         return [
             'http_errors' => false,
-            'delay' => 100,
-            'retries' => 3,
-            'query' => [
-                'fields' => 'country_code,postal,asn,threat',
-                'api-key' => $apiKey
-            ]
+            'delay'       => 100,
+            'retries'     => 3,
+            'query'       => [
+                'fields'  => 'country_code,postal,asn,threat',
+                'api-key' => $apiKey,
+            ],
         ];
     }
 

--- a/src/Api/Services/IPData.php
+++ b/src/Api/Services/IPData.php
@@ -1,83 +1,46 @@
 <?php
 
-/*
- * This file is part of fof/geoip.
- *
- * Copyright (c) FriendsOfFlarum.
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace FoF\GeoIP\Api\Services;
 
-use Flarum\Settings\SettingsRepositoryInterface;
 use FoF\GeoIP\Api\GeoIP;
-use FoF\GeoIP\Api\ServiceInterface;
 use FoF\GeoIP\Api\ServiceResponse;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
-use Illuminate\Support\Str;
 
-class IPData implements ServiceInterface
+class IPData extends BaseGeoService
 {
-    /**
-     * @var SettingsRepositoryInterface
-     */
-    protected $settings;
+    protected $host = 'https://api.ipdata.co';
+    protected $settingPrefix = 'fof-geoip.services.ipdata';
 
-    /**
-     * @var Client
-     */
-    private $client;
-
-    public function __construct(SettingsRepositoryInterface $settings)
+    protected function buildUrl(string $ip, ?string $apiKey): string
     {
-        $this->settings = $settings;
-
-        $this->client = new Client([
-            'base_uri' => 'https://api.ipdata.co',
-            'verify'   => false,
-        ]);
+        return "/{$ip}";
     }
 
-    /**
-     * @param string $ip
-     *
-     * @return ServiceResponse|null
-     */
-    public function get(string $ip)
+    protected function getRequestOptions(?string $apiKey): array
     {
-        $apiKey = $this->settings->get('fof-geoip.services.ipdata.access_key');
+        return [
+            'http_errors' => false,
+            'delay' => 100,
+            'retries' => 3,
+            'query' => [
+                'fields' => 'country_code,postal,asn,threat',
+                'api-key' => $apiKey
+            ]
+        ];
+    }
 
-        if (!$apiKey) {
-            return;
-        }
+    protected function hasError(object $body): bool
+    {
+        return isset($body->error);
+    }
 
-        $res = null;
+    protected function handleError(object $body): ?ServiceResponse
+    {
+        return GeoIP::setError('ipdata', $body->error->message ?? json_encode($body));
+    }
 
-        try {
-            $res = $this->client->get("/{$ip}", [
-                'query' => [
-                    'fields'  => 'country_code,postal,asn,threat',
-                    'api-key' => $apiKey,
-                ],
-            ]);
-        } catch (RequestException $e) {
-            $body = json_decode($e->getResponse()->getBody());
-            $error = $body->message;
-
-            if (Str::startsWith($error, 'You have either exceeded your quota or that API key does not exist.')) {
-                return GeoIP::setError('ipdata', $error);
-            }
-
-            return (new ServiceResponse())
-                ->setError($body->message);
-        }
-
-        $body = json_decode($res->getBody());
-
-        $data = (new ServiceResponse())
+    protected function parseResponse(object $body): ServiceResponse
+    {
+        $response = (new ServiceResponse())
             ->setCountryCode($body->country_code)
             ->setZipCode($body->postal)
             ->setThreatLevel($body->threat->is_threat)
@@ -85,12 +48,12 @@ class IPData implements ServiceInterface
 
         if (isset($body->asn->type)) {
             if ($body->asn->type == 'isp') {
-                $data->setIsp($body->asn->name);
+                $response->setIsp($body->asn->name);
             } else {
-                $data->setOrganization($body->asn->name);
+                $response->setOrganization($body->asn->name);
             }
         }
 
-        return $data;
+        return $response;
     }
 }

--- a/src/Api/Services/IPLocation.php
+++ b/src/Api/Services/IPLocation.php
@@ -11,45 +11,48 @@
 
 namespace FoF\GeoIP\Api\Services;
 
-use FoF\GeoIP\Api\ServiceInterface;
+use FoF\GeoIP\Api\GeoIP;
 use FoF\GeoIP\Api\ServiceResponse;
-use GuzzleHttp\Client;
 
-class IPLocation implements ServiceInterface
+class IPLocation extends BaseGeoService
 {
-    /**
-     * @var Client
-     */
-    private Client $client;
+    protected $host = 'https://api.iplocation.net';
+    protected $settingPrefix = 'fof-geoip.services.iplocation';
 
-    public function __construct()
+    protected function buildUrl(string $ip, ?string $apiKey): string
     {
-        $this->client = new Client([
-            'base_uri' => 'https://api.iplocation.net',
-        ]);
+        return "/?ip={$ip}";
     }
 
-    /**
-     * @param string $ip
-     *
-     * @return ServiceResponse|null
-     */
-    public function get(string $ip)
+
+    protected function getRequestOptions(?string $apiKey): array
     {
-        $res = $this->client->get(
-            '/',
-            ['query' => [
-                'ip' => $ip,
-            ]]
-        );
+        return [
+            'http_errors' => false,
+            'delay' => 100,
+            'retries' => 3,
+        ];
+    }
 
-        $body = json_decode($res->getBody());
+    protected function requiresApiKey(): bool
+    {
+        return false;
+    }
 
-        if ($body->response_code != '200') {
-            return (new ServiceResponse())
-                ->setError(sprintf('%s %s', $body->response_code, $body->response_message));
-        }
+    protected function hasError(object $body): bool
+    {
+        return $body->response_code !== '200';
+    }
 
+
+    protected function handleError(object $body): ?ServiceResponse
+    {
+        return GeoIP::setError('iplocation', sprintf('%s %s', $body->response_code, $body->response_message));
+    }
+
+
+    protected function parseResponse(object $body): ServiceResponse
+    {
         return (new ServiceResponse())
             ->setCountryCode($body->country_code2)
             ->setIsp($body->isp);

--- a/src/Api/Services/IPLocation.php
+++ b/src/Api/Services/IPLocation.php
@@ -24,13 +24,12 @@ class IPLocation extends BaseGeoService
         return "/?ip={$ip}";
     }
 
-
     protected function getRequestOptions(?string $apiKey): array
     {
         return [
             'http_errors' => false,
-            'delay' => 100,
-            'retries' => 3,
+            'delay'       => 100,
+            'retries'     => 3,
         ];
     }
 
@@ -44,12 +43,10 @@ class IPLocation extends BaseGeoService
         return $body->response_code !== '200';
     }
 
-
     protected function handleError(object $body): ?ServiceResponse
     {
         return GeoIP::setError('iplocation', sprintf('%s %s', $body->response_code, $body->response_message));
     }
-
 
     protected function parseResponse(object $body): ServiceResponse
     {

--- a/src/Api/Services/IPStack.php
+++ b/src/Api/Services/IPStack.php
@@ -29,14 +29,13 @@ class IPStack extends BaseGeoService
         return [
             'query' => [
                 'access_key' => $apiKey,
-                'security' => (int) $this->settings->get("{$this->settingPrefix}.security", 0),
+                'security'   => (int) $this->settings->get("{$this->settingPrefix}.security", 0),
             ],
             'http_errors' => false,
-            'delay' => 100,
-            'retries' => 3,
+            'delay'       => 100,
+            'retries'     => 3,
         ];
     }
-
 
     protected function hasError(object $body): bool
     {

--- a/src/Api/Services/IPStack.php
+++ b/src/Api/Services/IPStack.php
@@ -11,69 +11,45 @@
 
 namespace FoF\GeoIP\Api\Services;
 
-use Flarum\Settings\SettingsRepositoryInterface;
 use FoF\GeoIP\Api\GeoIP;
-use FoF\GeoIP\Api\ServiceInterface;
 use FoF\GeoIP\Api\ServiceResponse;
-use GuzzleHttp\Client;
 
-class IPStack implements ServiceInterface
+class IPStack extends BaseGeoService
 {
-    /**
-     * @var SettingsRepositoryInterface
-     */
-    protected $settings;
-
-    /**
-     * @var Client
-     */
-    private $client;
-
     protected $host = 'https://api.ipstack.com';
     protected $settingPrefix = 'fof-geoip.services.ipstack';
 
-    public function __construct(SettingsRepositoryInterface $settings)
+    protected function buildUrl(string $ip, ?string $apiKey): string
     {
-        $this->settings = $settings;
-
-        $this->client = new Client([
-            'base_uri' => $this->host,
-            'verify'   => false,
-        ]);
+        return "/api/{$ip}";
     }
 
-    /**
-     * @param string $ip
-     *
-     * @return ServiceResponse|null
-     */
-    public function get(string $ip): ?ServiceResponse
+    protected function getRequestOptions(?string $apiKey): array
     {
-        $accessKey = $this->settings->get("{$this->settingPrefix}.access_key");
+        return [
+            'query' => [
+                'access_key' => $apiKey,
+                'security' => (int) $this->settings->get("{$this->settingPrefix}.security", 0),
+            ],
+            'http_errors' => false,
+            'delay' => 100,
+            'retries' => 3,
+        ];
+    }
 
-        if (!$accessKey) {
-            return null;
-        }
 
-        $res = $this->client->get(
-            "/api/{$ip}",
-            ['query' => [
-                'access_key' => $accessKey,
-                'security'   => (int) $this->settings->get("{$this->settingPrefix}.security", 0),
-            ]]
-        );
+    protected function hasError(object $body): bool
+    {
+        return isset($body->success) && !$body->success;
+    }
 
-        $body = json_decode($res->getBody());
+    protected function handleError(object $body): ?ServiceResponse
+    {
+        return GeoIP::setError('ipstack', $body->error->info ?? json_encode($body));
+    }
 
-        if (isset($body->success) && !$body->success) {
-            return GeoIP::setError(
-                'ipstack',
-                isset($body->error->info)
-                    ? $body->error->info
-                    : json_encode($body)
-            );
-        }
-
+    protected function parseResponse(object $body): ServiceResponse
+    {
         $data = (new ServiceResponse())
             ->setCountryCode($body->country_code)
             ->setZipCode($body->zip);

--- a/src/Jobs/RetrieveIP.php
+++ b/src/Jobs/RetrieveIP.php
@@ -14,7 +14,7 @@ namespace FoF\GeoIP\Jobs;
 use Flarum\Queue\AbstractJob;
 use FoF\GeoIP\Api\GeoIP;
 use FoF\GeoIP\IPInfo;
-use Illuminate\Cache\Repository;
+use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Support\Arr;
 
 class RetrieveIP extends AbstractJob

--- a/src/Traits/HandlesGeoIPErrors.php
+++ b/src/Traits/HandlesGeoIPErrors.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of fof/geoip.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\GeoIP\Traits;
+
+use FoF\GeoIP\Api\ServiceResponse;
+
+trait HandlesGeoIPErrors
+{
+    protected function handleGeoIPError($error): ServiceResponse
+    {
+        return (new ServiceResponse(true))
+            ->setError($error);
+    }
+}


### PR DESCRIPTION
### Overview:

This PR introduces several enhancements to `fof/geoip`. The primary change is the introduction of a base class for the GeoIP services, which refactors and streamlines the service implementations.

Additionally, a trait for handling `GeoIP` errors has been added, and localization updates have been made.

### Key Changes:

- **Localization Update**: The description for the IPData service in resources/locale/en.yml has been updated to mention the availability of paid plans for higher usage limits.
- **Refactoring GeoIP Service Classes**: A new base class BaseGeoService has been introduced in `Api/Services/BaseGeoService.php`. This abstracts away common functionality from the individual service classes, providing a cleaner and more standardized approach.
    - The service classes for `IPApi`, `IPData`, `IPLocation`, and `IPStack` have been refactored to extend this new base class.
    - Common methods such as building the request URL, checking for errors, and handling errors have been abstracted into the base class.
- **Handling GeoIP Errors**: A new trait HandlesGeoIPErrors has been added in `Traits/HandlesGeoIPErrors.php`. This trait provides a method to handle `GeoIP` errors and is used in the `GeoIP` class.
- **Miscellaneous Updates**:
    - The constructor of the `GeoIP` class has been updated to use the shorthand syntax for property promotion.
    - The `RetrieveIP` class has been updated to use the contract for the cache repository instead of the concrete implementation..
