### PR TITLE
Fixes Deprecated Warning in BasicIPInfoSerializer.php

### DIFF
--- a/src/Api/Serializer/BasicIPInfoSerializer.php
+++ b/src/Api/Serializer/BasicIPInfoSerializer.php
@@ -44,6 +44,6 @@ class BasicIPInfoSerializer extends AbstractSerializer
      */
     public function getId($model)
     {
-        return hash('sha256', $model->address);
+        return hash('sha256', (string)$model->address);
     }
 }


### PR DESCRIPTION
Fixes Deprecated Warning in BasicIPInfoSerializer.php

Changes proposed in this pull request: This pull request addresses a deprecation warning related to the hash() function in BasicIPInfoSerializer.php (line 47). The warning occurs because null is being passed to the second parameter of hash(), which expects a string. To resolve this, I have explicitly cast the second parameter to a string.

Reviewers should focus on: Please review the changes to ensure that the casting of the second parameter in hash() does not introduce any unintended side effects. Also, verify if this resolves the deprecation warning as expected.

Screenshot: N/A

Confirmed:

[x] Frontend changes: Not applicable.
[x] Backend changes: Tests are green.
Required changes:

N/A


Base Error: Deprecated: hash(): Passing null to parameter #2 ($data) of type string is deprecated in /www/wwwroot/*/vendor/fof/geoip/src/Api/Serializer/BasicIPInfoSerializer.php on line 47

