### PR TITLE
[2.x] feat: proxy Nominatim requests server-side for privacy

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -130,5 +130,6 @@ return [
     new Extend\ApiResource(Api\Resource\IPInfoResource::class),
 
     (new Extend\Routes('api'))
-        ->get('/geoip/test', 'fof-geoip.test', Api\Controller\TestGeoipController::class),
+        ->get('/geoip/test', 'fof-geoip.test', Api\Controller\TestGeoipController::class)
+        ->get('/geoip/nominatim', 'fof-geoip.nominatim', Api\Controller\NominatimController::class),
 ];

--- a/js/src/common/components/ZipCodeMap.tsx
+++ b/js/src/common/components/ZipCodeMap.tsx
@@ -65,12 +65,12 @@ export default class ZipCodeMap extends Component<ZipCodeMapAttrs> {
     this.loading = true;
 
     const data = await app.request<NominatimResult>({
-      url: 'https://nominatim.openstreetmap.org/reverse',
+      url: app.forum.attribute('apiUrl') + '/geoip/nominatim',
       method: 'GET',
       params: {
+        type: 'reverse',
         lat: this.ipInfo.latitude(),
         lon: this.ipInfo.longitude(),
-        format: 'json',
       },
     });
 
@@ -86,13 +86,12 @@ export default class ZipCodeMap extends Component<ZipCodeMapAttrs> {
     this.loading = true;
 
     const data = await app.request<NominatimResult[]>({
-      url: 'https://nominatim.openstreetmap.org/search',
+      url: app.forum.attribute('apiUrl') + '/geoip/nominatim',
       method: 'GET',
       params: {
+        type: 'search',
         q: this.ipInfo.zipCode(),
         countrycodes: this.ipInfo.countryCode(),
-        limit: 1,
-        format: 'json',
       },
     });
 
@@ -120,7 +119,24 @@ export default class ZipCodeMap extends Component<ZipCodeMapAttrs> {
 
     this.map = L.map(vnode.dom as HTMLElement).setView([centerLat, centerLon], zoomLevel);
 
-    L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    // OSM requires a Referer header. Some browser/page Referrer-Policy configs
+    // strip it, causing 403 "Access blocked" on affected tiles. Extend TileLayer
+    // to set referrerpolicy="origin" on each img *before* src is assigned so the
+    // browser sends the origin as referer. Leaflet 1.9 has no native support.
+    const OsmTileLayer = L.TileLayer.extend({
+      createTile(this: any, coords: L.Coords, done: L.DoneCallback) {
+        const tile = document.createElement('img');
+        tile.referrerPolicy = 'origin';
+        tile.alt = '';
+        tile.setAttribute('role', 'presentation');
+        L.DomEvent.on(tile, 'load', this._tileOnLoad.bind(this, done, tile));
+        L.DomEvent.on(tile, 'error', this._tileOnError.bind(this, done, tile));
+        tile.src = this.getTileUrl(coords);
+        return tile;
+      },
+    }) as unknown as new (url: string, options?: L.TileLayerOptions) => L.TileLayer;
+
+    new OsmTileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
       attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
     }).addTo(this.map);
 

--- a/src/Api/Controller/NominatimController.php
+++ b/src/Api/Controller/NominatimController.php
@@ -1,0 +1,182 @@
+<?php
+
+/*
+ * This file is part of fof/geoip.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\GeoIP\Api\Controller;
+
+use Flarum\Http\RequestUtil;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\GuzzleException;
+use Illuminate\Contracts\Cache\Repository as Cache;
+use Illuminate\Support\Arr;
+use Laminas\Diactoros\Response\JsonResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Proxies Nominatim API requests server-side so the admin's browser IP is not
+ * exposed to OpenStreetMap, and so Nominatim receives a proper User-Agent and
+ * Referer identifying this installation (as required by the Nominatim usage policy).
+ */
+class NominatimController implements RequestHandlerInterface
+{
+    private const NOMINATIM_BASE = 'https://nominatim.openstreetmap.org';
+    private const CONNECT_TIMEOUT = 5;
+    private const REQUEST_TIMEOUT = 10;
+    private const MAX_RESPONSE_BYTES = 512 * 1024; // 512 KB
+    private const CACHE_TTL = 7 * 24 * 60 * 60;   // 7 days — matches OSM tile caching guidance
+
+    public function __construct(protected Cache $cache)
+    {
+        $this->client = new Client([
+            'connect_timeout' => self::CONNECT_TIMEOUT,
+            'timeout'         => self::REQUEST_TIMEOUT,
+            'http_errors'     => false,
+        ]);
+    }
+
+    private Client $client;
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $actor = RequestUtil::getActor($request);
+        $actor->assertPermission($actor->can('viewIps'));
+
+        $params = $request->getQueryParams();
+        $type = Arr::get($params, 'type', '');
+
+        return match ($type) {
+            'reverse' => $this->reverse($params),
+            'search'  => $this->search($params),
+            default   => new JsonResponse([
+                'errors' => [['status' => '400', 'title' => 'Bad Request', 'detail' => 'Invalid type parameter. Use "reverse" or "search".']],
+            ], 400),
+        };
+    }
+
+    private function reverse(array $params): ResponseInterface
+    {
+        $lat = Arr::get($params, 'lat');
+        $lon = Arr::get($params, 'lon');
+
+        if (!is_numeric($lat) || !is_numeric($lon)) {
+            return new JsonResponse([
+                'errors' => [['status' => '400', 'title' => 'Bad Request', 'detail' => 'lat and lon must be numeric.']],
+            ], 400);
+        }
+
+        $lat = (float) $lat;
+        $lon = (float) $lon;
+
+        if ($lat < -90 || $lat > 90 || $lon < -180 || $lon > 180) {
+            return new JsonResponse([
+                'errors' => [['status' => '400', 'title' => 'Bad Request', 'detail' => 'lat must be between -90 and 90, lon between -180 and 180.']],
+            ], 400);
+        }
+
+        return $this->nominatimRequest('/reverse', [
+            'lat'    => $lat,
+            'lon'    => $lon,
+            'format' => 'json',
+        ]);
+    }
+
+    private function search(array $params): ResponseInterface
+    {
+        $q = trim((string) Arr::get($params, 'q', ''));
+        $countrycodes = trim((string) Arr::get($params, 'countrycodes', ''));
+
+        if ($q === '') {
+            return new JsonResponse([
+                'errors' => [['status' => '400', 'title' => 'Bad Request', 'detail' => 'q parameter is required.']],
+            ], 400);
+        }
+
+        if (strlen($q) > 200) {
+            return new JsonResponse([
+                'errors' => [['status' => '400', 'title' => 'Bad Request', 'detail' => 'q parameter is too long.']],
+            ], 400);
+        }
+
+        $query = [
+            'q'      => $q,
+            'limit'  => 1,
+            'format' => 'json',
+        ];
+
+        if ($countrycodes !== '') {
+            // Validate: ISO 3166-1 alpha-2 codes only (comma-separated)
+            if (!preg_match('/^[a-zA-Z]{2}(,[a-zA-Z]{2})*$/', $countrycodes)) {
+                return new JsonResponse([
+                    'errors' => [['status' => '400', 'title' => 'Bad Request', 'detail' => 'countrycodes must be comma-separated ISO 3166-1 alpha-2 codes.']],
+                ], 400);
+            }
+            $query['countrycodes'] = strtolower($countrycodes);
+        }
+
+        return $this->nominatimRequest('/search', $query);
+    }
+
+    private function nominatimRequest(string $path, array $query): ResponseInterface
+    {
+        $cacheKey = 'fof-geoip.nominatim.'.md5($path.serialize($query));
+
+        if ($cached = $this->cache->get($cacheKey)) {
+            return new JsonResponse($cached);
+        }
+
+        try {
+            $response = $this->client->get(self::NOMINATIM_BASE.$path, [
+                'query'   => $query,
+                'headers' => [
+                    'User-Agent' => 'fof/geoip Flarum extension (https://github.com/FriendsOfFlarum/geoip)',
+                    'Referer'    => self::NOMINATIM_BASE,
+                ],
+            ]);
+
+            $status = $response->getStatusCode();
+
+            if ($status === 429) {
+                return new JsonResponse([
+                    'errors' => [['status' => '429', 'title' => 'Too Many Requests', 'detail' => 'Nominatim rate limit reached. Please try again later.']],
+                ], 429);
+            }
+
+            if ($status < 200 || $status >= 300) {
+                return new JsonResponse([
+                    'errors' => [['status' => '502', 'title' => 'Bad Gateway', 'detail' => "Nominatim returned HTTP {$status}."]],
+                ], 502);
+            }
+
+            $body = $response->getBody()->read(self::MAX_RESPONSE_BYTES);
+            $data = json_decode($body, true);
+
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                return new JsonResponse([
+                    'errors' => [['status' => '502', 'title' => 'Bad Gateway', 'detail' => 'Invalid JSON response from Nominatim.']],
+                ], 502);
+            }
+
+            $this->cache->put($cacheKey, $data, self::CACHE_TTL);
+
+            return new JsonResponse($data);
+        } catch (ConnectException) {
+            return new JsonResponse([
+                'errors' => [['status' => '504', 'title' => 'Gateway Timeout', 'detail' => 'Could not connect to Nominatim.']],
+            ], 504);
+        } catch (GuzzleException) {
+            return new JsonResponse([
+                'errors' => [['status' => '502', 'title' => 'Bad Gateway', 'detail' => 'Nominatim request failed.']],
+            ], 502);
+        }
+    }
+}

--- a/tests/integration/Api/NominatimControllerTest.php
+++ b/tests/integration/Api/NominatimControllerTest.php
@@ -1,0 +1,219 @@
+<?php
+
+/*
+ * This file is part of fof/geoip.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\GeoIP\Tests\integration\Api;
+
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+class NominatimControllerTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-geoip');
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+            'group_permission' => [
+                ['group_id' => 4, 'permission' => 'viewIps'],
+            ],
+            'group_user' => [
+                ['user_id' => 2, 'group_id' => 4],
+            ],
+        ]);
+    }
+
+    public static function nonAuthorizedUsers(): array
+    {
+        return [
+            'guest'            => [null],
+            'user without perm' => [3],
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // Permission checks
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    #[DataProvider('nonAuthorizedUsers')]
+    public function unauthorized_users_cannot_access_nominatim_proxy(?int $userId)
+    {
+        // Add a user without viewIps for the data provider case
+        $this->prepareDatabase([
+            User::class => [
+                ['id' => 3, 'username' => 'noperm', 'email' => 'noperm@example.com', 'is_email_confirmed' => 1],
+            ],
+        ]);
+
+        $response = $this->send(
+            $this->request('GET', '/api/geoip/nominatim', ['authenticatedAs' => $userId])
+                ->withQueryParams(['type' => 'reverse', 'lat' => '51.5', 'lon' => '-0.1'])
+        );
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function admin_can_access_nominatim_proxy()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/geoip/nominatim', ['authenticatedAs' => 1])
+                ->withQueryParams(['type' => 'reverse', 'lat' => '51.5', 'lon' => '-0.1'])
+        );
+
+        // 200 or 502 (if Nominatim is unreachable in CI) — either way, not a 403/401
+        $this->assertNotEquals(403, $response->getStatusCode());
+        $this->assertNotEquals(401, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function user_with_viewips_permission_can_access_nominatim_proxy()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/geoip/nominatim', ['authenticatedAs' => 2])
+                ->withQueryParams(['type' => 'reverse', 'lat' => '51.5', 'lon' => '-0.1'])
+        );
+
+        $this->assertNotEquals(403, $response->getStatusCode());
+        $this->assertNotEquals(401, $response->getStatusCode());
+    }
+
+    // -------------------------------------------------------------------------
+    // Input validation — type param
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function missing_type_returns_400()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/geoip/nominatim', ['authenticatedAs' => 1])
+                ->withQueryParams(['lat' => '51.5', 'lon' => '-0.1'])
+        );
+
+        $this->assertEquals(400, $response->getStatusCode());
+        $data = json_decode($response->getBody(), true);
+        $this->assertArrayHasKey('errors', $data);
+    }
+
+    #[Test]
+    public function invalid_type_returns_400()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/geoip/nominatim', ['authenticatedAs' => 1])
+                ->withQueryParams(['type' => 'forward', 'q' => 'London'])
+        );
+
+        $this->assertEquals(400, $response->getStatusCode());
+        $data = json_decode($response->getBody(), true);
+        $this->assertStringContainsString('"reverse" or "search"', $data['errors'][0]['detail']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Input validation — reverse
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function reverse_with_missing_lat_returns_400()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/geoip/nominatim', ['authenticatedAs' => 1])
+                ->withQueryParams(['type' => 'reverse', 'lon' => '-0.1'])
+        );
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function reverse_with_non_numeric_lat_returns_400()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/geoip/nominatim', ['authenticatedAs' => 1])
+                ->withQueryParams(['type' => 'reverse', 'lat' => 'abc', 'lon' => '-0.1'])
+        );
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function reverse_with_out_of_range_lat_returns_400()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/geoip/nominatim', ['authenticatedAs' => 1])
+                ->withQueryParams(['type' => 'reverse', 'lat' => '91', 'lon' => '0'])
+        );
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function reverse_with_out_of_range_lon_returns_400()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/geoip/nominatim', ['authenticatedAs' => 1])
+                ->withQueryParams(['type' => 'reverse', 'lat' => '0', 'lon' => '181'])
+        );
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    // -------------------------------------------------------------------------
+    // Input validation — search
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function search_with_missing_q_returns_400()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/geoip/nominatim', ['authenticatedAs' => 1])
+                ->withQueryParams(['type' => 'search'])
+        );
+
+        $this->assertEquals(400, $response->getStatusCode());
+        $data = json_decode($response->getBody(), true);
+        $this->assertStringContainsString('q parameter is required', $data['errors'][0]['detail']);
+    }
+
+    #[Test]
+    public function search_with_oversized_q_returns_400()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/geoip/nominatim', ['authenticatedAs' => 1])
+                ->withQueryParams(['type' => 'search', 'q' => str_repeat('a', 201)])
+        );
+
+        $this->assertEquals(400, $response->getStatusCode());
+        $data = json_decode($response->getBody(), true);
+        $this->assertStringContainsString('too long', $data['errors'][0]['detail']);
+    }
+
+    #[Test]
+    public function search_with_invalid_countrycodes_returns_400()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/geoip/nominatim', ['authenticatedAs' => 1])
+                ->withQueryParams(['type' => 'search', 'q' => 'London', 'countrycodes' => 'not_valid!'])
+        );
+
+        $this->assertEquals(400, $response->getStatusCode());
+        $data = json_decode($response->getBody(), true);
+        $this->assertStringContainsString('ISO 3166-1', $data['errors'][0]['detail']);
+    }
+}

--- a/tests/integration/Api/NominatimControllerTest.php
+++ b/tests/integration/Api/NominatimControllerTest.php
@@ -43,7 +43,7 @@ class NominatimControllerTest extends TestCase
     public static function nonAuthorizedUsers(): array
     {
         return [
-            'guest'            => [null],
+            'guest'             => [null],
             'user without perm' => [3],
         ];
     }

--- a/tests/phpunit.integration.xml
+++ b/tests/phpunit.integration.xml
@@ -1,25 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-    backupGlobals="false"
-    backupStaticAttributes="false"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="true"
     stopOnFailure="false"
 >
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">../src/</directory>
         </include>
-    </coverage>
+    </source>
     <testsuites>
         <testsuite name="Flarum Integration Tests">
             <directory suffix="Test.php">./integration</directory>
-             <exclude>./integration/tmp</exclude>
+            <exclude>./integration/tmp</exclude>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/phpunit.unit.xml
+++ b/tests/phpunit.unit.xml
@@ -1,27 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-    backupGlobals="false"
-    backupStaticAttributes="false"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
 >
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">../src/</directory>
         </include>
-    </coverage>
+    </source>
     <testsuites>
         <testsuite name="Flarum Unit Tests">
             <directory suffix="Test.php">./unit</directory>
         </testsuite>
     </testsuites>
-    <listeners>
-        <listener class="\Mockery\Adapter\Phpunit\TestListener" />
-    </listeners>
 </phpunit>


### PR DESCRIPTION
## Summary

- Adds `GET /api/geoip/nominatim` — a server-side proxy for Nominatim reverse-geocode and search requests, so the admin's browser IP is never exposed to OpenStreetMap
- Sets the required `User-Agent` and `Referer` headers per Nominatim usage policy; caches results for 7 days; enforces `viewIps` permission; validates and sanitises all inputs
- Fixes OSM tile 403 "Access blocked" errors by setting `referrerpolicy="origin"` on each Leaflet tile `<img>` before `src` is assigned
- Updates PHPUnit config schema from 9.3 to 11.0, removing deprecated attributes