### PR TITLE
[2.x] fix: use discussion.viewIpsPosts instead of viewIps for permission checks

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -102,7 +102,7 @@ return [
                     $actor = $context->getActor();
                     $settings = resolve(SettingsRepositoryInterface::class);
 
-                    return $actor->can('viewIps')
+                    return $actor->can('discussion.viewIpsPosts')
                         || $actor->can('fof-geoip.canSeeCountry')
                         || (bool) $settings->get('fof-geoip.showFlag');
                 }),

--- a/src/Api/Controller/NominatimController.php
+++ b/src/Api/Controller/NominatimController.php
@@ -49,7 +49,7 @@ class NominatimController implements RequestHandlerInterface
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $actor = RequestUtil::getActor($request);
-        $actor->assertPermission($actor->can('viewIps'));
+        $actor->assertPermission($actor->can('discussion.viewIpsPosts'));
 
         $params = $request->getQueryParams();
         $type = Arr::get($params, 'type', '');

--- a/src/Api/Resource/IPInfoResource.php
+++ b/src/Api/Resource/IPInfoResource.php
@@ -97,35 +97,35 @@ class IPInfoResource extends Resource\AbstractDatabaseResource
             // Full details - only for users who can view IPs
             Schema\Str::make('ip')
                 ->property('address')
-                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('viewIps')),
+                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('discussion.viewIpsPosts')),
             Schema\Str::make('zipCode')
-                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('viewIps')),
+                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('discussion.viewIpsPosts')),
             Schema\Str::make('latitude')
-                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('viewIps')),
+                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('discussion.viewIpsPosts')),
             Schema\Str::make('longitude')
-                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('viewIps')),
+                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('discussion.viewIpsPosts')),
             Schema\Str::make('isp')
-                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('viewIps')),
+                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('discussion.viewIpsPosts')),
             Schema\Str::make('organization')
-                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('viewIps')),
+                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('discussion.viewIpsPosts')),
             Schema\Str::make('as')
-                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('viewIps')),
+                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('discussion.viewIpsPosts')),
             Schema\Boolean::make('mobile')
-                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('viewIps')),
+                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('discussion.viewIpsPosts')),
             Schema\Str::make('threatLevel')
-                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('viewIps')),
+                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('discussion.viewIpsPosts')),
             Schema\Str::make('threatType')
                 ->property('threat_types')
-                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('viewIps')),
+                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('discussion.viewIpsPosts')),
             Schema\Str::make('error')
                 ->nullable()
-                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('viewIps')),
+                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('discussion.viewIpsPosts')),
             Schema\Str::make('dataProvider')
-                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('viewIps')),
+                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('discussion.viewIpsPosts')),
             Schema\DateTime::make('createdAt')
-                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('viewIps')),
+                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('discussion.viewIpsPosts')),
             Schema\DateTime::make('updatedAt')
-                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('viewIps')),
+                ->visible(fn (IPInfo $ipInfo, Context $context) => $context->getActor()->can('discussion.viewIpsPosts')),
         ];
     }
 

--- a/tests/integration/Api/IpInfoVisibilityTest.php
+++ b/tests/integration/Api/IpInfoVisibilityTest.php
@@ -57,7 +57,7 @@ class IpInfoVisibilityTest extends TestCase
             ],
             'group_permission' => [
                 ['group_id' => 10, 'permission' => 'fof-geoip.canSeeCountry'], // Custom group gets canSeeCountry only
-                ['group_id' => 4,  'permission' => 'viewIps'],                 // Mods group gets viewIps
+                ['group_id' => 4,  'permission' => 'discussion.viewIpsPosts'], // Mods group gets viewIps
             ],
             'group_user' => [
                 ['user_id' => 3, 'group_id' => 10], // canseecountry → Country Viewers (canSeeCountry only, no viewIps)

--- a/tests/integration/Api/NominatimControllerTest.php
+++ b/tests/integration/Api/NominatimControllerTest.php
@@ -32,7 +32,7 @@ class NominatimControllerTest extends TestCase
                 $this->normalUser(),
             ],
             'group_permission' => [
-                ['group_id' => 4, 'permission' => 'viewIps'],
+                ['group_id' => 4, 'permission' => 'discussion.viewIpsPosts'],
             ],
             'group_user' => [
                 ['user_id' => 2, 'group_id' => 4],

--- a/tests/integration/Api/ShowIPEndpontTest.php
+++ b/tests/integration/Api/ShowIPEndpontTest.php
@@ -35,7 +35,7 @@ class ShowIPEndpontTest extends TestCase
                 ['user_id' => 2, 'group_id' => 4], // Make normal user a moderator
             ],
             'group_permission' => [
-                ['group_id' => 4, 'permission' => 'viewIps'], // Give moderators permission to view IP info
+                ['group_id' => 4, 'permission' => 'discussion.viewIpsPosts'], // Give moderators permission to view IP info
             ],
         ]);
     }


### PR DESCRIPTION
## Summary

- `can('viewIps')` without a model bypasses `PostPolicy`, which is what translates `viewIps` → `discussion.viewIpsPosts`. Only admins were passing the check — moderators with the viewIps group permission were silently receiving `countryCode` only instead of full `ip_info` fields.
- Fixes the permission check in `IPInfoResource` (all sensitive field visibility guards), `NominatimController` (endpoint gate), and the `fofGeoipCanSeeIpInfo` forum attribute in `extend.php`.
- Updates all test fixtures to use the correct `discussion.viewIpsPosts` permission name.