### PR TITLE
[2.x] Enhance IPAddress component in admin as well as forum

### DIFF
--- a/js/src/admin/index.ts
+++ b/js/src/admin/index.ts
@@ -1,8 +1,10 @@
 import app from 'flarum/admin/app';
 import GeoipSettingsPage from './components/GeoipSettingsPage';
+import extendIpAddress from '../common/extenders/extendIpAddress';
 
 export { default as extend } from './extend';
 
 app.initializers.add('fof/geoip', () => {
   GeoipSettingsPage.register();
+  extendIpAddress();
 });

--- a/js/src/common/components/MapModal.tsx
+++ b/js/src/common/components/MapModal.tsx
@@ -28,7 +28,7 @@ export default class MapModal extends Modal<MapModalAttrs> {
   }
 
   title() {
-    return app.translator.trans('fof-geoip.forum.map_modal.title');
+    return app.translator.trans('fof-geoip.lib.map_modal.title');
   }
 
   content() {
@@ -47,11 +47,11 @@ export default class MapModal extends Modal<MapModalAttrs> {
         <div className="IPDetails">
           {this.dataItems().toArray()}
 
-          {ipInfo.threatLevel() && <LabelValue label={app.translator.trans('fof-geoip.forum.map_modal.threat_level')} value={ipInfo.threatLevel()} />}
+          {ipInfo.threatLevel() && <LabelValue label={app.translator.trans('fof-geoip.lib.map_modal.threat_level')} value={ipInfo.threatLevel()} />}
           {ipInfo.threatTypes().length > 0 && (
-            <LabelValue label={app.translator.trans('fof-geoip.forum.map_modal.threat_types')} value={ipInfo.threatTypes().join(', ')} />
+            <LabelValue label={app.translator.trans('fof-geoip.lib.map_modal.threat_types')} value={ipInfo.threatTypes().join(', ')} />
           )}
-          {ipInfo.error() && <LabelValue label={app.translator.trans('fof-geoip.forum.map_modal.error')} value={ipInfo.error()} />}
+          {ipInfo.error() && <LabelValue label={app.translator.trans('fof-geoip.lib.map_modal.error')} value={ipInfo.error()} />}
         </div>
         <hr />
         <div className="IPDetails--map">{this.mapItems().toArray()}</div>
@@ -65,7 +65,7 @@ export default class MapModal extends Modal<MapModalAttrs> {
     items.add(
       'ipAddress',
       <LabelValue
-        label={app.translator.trans('fof-geoip.forum.map_modal.ip_address')}
+        label={app.translator.trans('fof-geoip.lib.map_modal.ip_address')}
         value={
           <span className="clickable-ip" onclick={handleCopyIP(this.ipAddr)}>
             {this.ipAddr}
@@ -79,28 +79,28 @@ export default class MapModal extends Modal<MapModalAttrs> {
       this.ipInfo.countryCode?.() &&
         items.add(
           'countryCode',
-          <LabelValue label={app.translator.trans('fof-geoip.forum.map_modal.country_code')} value={this.ipInfo.countryCode()} />,
+          <LabelValue label={app.translator.trans('fof-geoip.lib.map_modal.country_code')} value={this.ipInfo.countryCode()} />,
           90
         );
 
       this.ipInfo.zipCode?.() &&
-        items.add('zipCode', <LabelValue label={app.translator.trans('fof-geoip.forum.map_modal.zip_code')} value={this.ipInfo.zipCode()} />, 80);
+        items.add('zipCode', <LabelValue label={app.translator.trans('fof-geoip.lib.map_modal.zip_code')} value={this.ipInfo.zipCode()} />, 80);
 
       this.ipInfo.isp?.() &&
-        items.add('isp', <LabelValue label={app.translator.trans('fof-geoip.forum.map_modal.isp')} value={this.ipInfo.isp()} />, 70);
+        items.add('isp', <LabelValue label={app.translator.trans('fof-geoip.lib.map_modal.isp')} value={this.ipInfo.isp()} />, 70);
 
       this.ipInfo.organization?.() &&
         items.add(
           'organization',
-          <LabelValue label={app.translator.trans('fof-geoip.forum.map_modal.organization')} value={this.ipInfo.organization()} />,
+          <LabelValue label={app.translator.trans('fof-geoip.lib.map_modal.organization')} value={this.ipInfo.organization()} />,
           60
         );
 
-      this.ipInfo.as?.() && items.add('as', <LabelValue label={app.translator.trans('fof-geoip.forum.map_modal.as')} value={this.ipInfo.as()} />, 50);
+      this.ipInfo.as?.() && items.add('as', <LabelValue label={app.translator.trans('fof-geoip.lib.map_modal.as')} value={this.ipInfo.as()} />, 50);
 
       items.add(
         'mobileNetwork',
-        <LabelValue label={app.translator.trans('fof-geoip.forum.map_modal.mobile')} value={this.ipInfo.mobile() ? 'yes' : 'no'} />,
+        <LabelValue label={app.translator.trans('fof-geoip.lib.map_modal.mobile')} value={this.ipInfo.mobile() ? 'yes' : 'no'} />,
         40
       );
     }

--- a/js/src/common/components/ZipCodeMap.tsx
+++ b/js/src/common/components/ZipCodeMap.tsx
@@ -51,7 +51,7 @@ export default class ZipCodeMap extends Component<ZipCodeMapAttrs> {
     if (this.loading) {
       return <LoadingIndicator size="medium" />;
     } else if (this.data && 'unknown' in this.data) {
-      return <div className="helpText">{app.translator.trans('fof-geoip.forum.map_modal.not_enough_data')}</div>;
+      return <div className="helpText">{app.translator.trans('fof-geoip.lib.map_modal.not_enough_data')}</div>;
     } else if (!this.data) {
       return <div />;
     }

--- a/js/src/common/extenders/extendIpAddress.tsx
+++ b/js/src/common/extenders/extendIpAddress.tsx
@@ -35,12 +35,12 @@ export default function extendIpAddress() {
 
       items.add(
         'copyButton',
-        <Tooltip text={app.translator.trans('fof-geoip.forum.copy_ip_label')}>
+        <Tooltip text={app.translator.trans('fof-geoip.lib.copy_ip_label')}>
           <Button
             icon="fas fa-copy"
             className="Button Button--icon Button--link"
             onclick={handleCopyIP(this.ip)}
-            aria-label={app.translator.trans('fof-geoip.forum.copy_ip_label')}
+            aria-label={app.translator.trans('fof-geoip.lib.copy_ip_label')}
           />
         </Tooltip>,
         95
@@ -48,7 +48,7 @@ export default function extendIpAddress() {
 
       items.add(
         'infoButton',
-        <Tooltip text={app.translator.trans('fof-geoip.forum.map_button_label')}>
+        <Tooltip text={app.translator.trans('fof-geoip.lib.map_button_label')}>
           <Button
             icon="fas fa-info-circle"
             className="Button Button--icon Button--link"
@@ -56,7 +56,7 @@ export default function extendIpAddress() {
               e.stopPropagation();
               app.modal.show(() => import('../components/MapModal'), { ipInfo: this.ipInfo, ipAddr: this.ip });
             }}
-            aria-label={app.translator.trans('fof-geoip.forum.map_button_label')}
+            aria-label={app.translator.trans('fof-geoip.lib.map_button_label')}
           />
         </Tooltip>,
         90

--- a/js/src/common/helpers/ClipboardHelper.ts
+++ b/js/src/common/helpers/ClipboardHelper.ts
@@ -4,6 +4,6 @@ import copyToClipboard from '../util/copyToClipboard';
 export const handleCopyIP = (ip: string) => {
   return () => {
     copyToClipboard(ip);
-    app.alerts.show({ type: 'success' }, app.translator.trans('fof-geoip.forum.alerts.ip_copied'));
+    app.alerts.show({ type: 'success' }, app.translator.trans('fof-geoip.lib.alerts.ip_copied'));
   };
 };

--- a/resources/less/admin.less
+++ b/resources/less/admin.less
@@ -1,3 +1,6 @@
+@import (inline) "../../assets/leaflet.css";
+@import "common.less";
+
 .GeoipSettingsPage {
     padding-top: 20px;
 

--- a/resources/less/common.less
+++ b/resources/less/common.less
@@ -1,0 +1,68 @@
+// Styles shared between the forum and admin frontends.
+// Imported by both forum.less and admin.less so the enhanced <IPAddress>
+// component and MapModal render identically wherever they appear.
+
+.ip-container {
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+  overflow: hidden;
+
+  > span {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 90%;
+  }
+
+  img {
+      margin-right: 10px;
+      vertical-align: text-top;
+  }
+}
+
+.Modal #geoip-map {
+  height: 300px;
+  resize: vertical;
+  overflow: hidden;
+}
+
+.MapModal {
+  .IPSubtitle {
+    font-size: 1em;
+    font-weight: normal;
+    color: var(--muted-color);
+    margin-top: -10px;
+    margin-bottom: 20px;
+  }
+
+  .IPDetails {
+    margin-bottom: 15px;
+    padding: 10px;
+    border: 1px solid var(--muted-color);
+    border-radius: @border-radius;
+    background-color: var(--control-bg);
+
+    h3 {
+      font-size: 1.25em;
+      margin-top: 0;
+      margin-bottom: 10px;
+      color: @primary-color;
+    }
+
+    p {
+      margin: 5px 0;
+      color: var(--text-color);
+    }
+  }
+
+  .clickable-ip:hover {
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  #mapContainer {
+    margin-top: 10px;
+    border: 1px solid var(--muted-color);
+    border-radius: @border-radius;
+  }
+}

--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -1,4 +1,5 @@
 @import (inline) "../../assets/leaflet.css";
+@import "common.less";
 
 .PostMeta {
   .PostMeta-ip, .Modal div label[for="ban-option-only"] {
@@ -30,75 +31,10 @@
   }
 }
 
-.ip-container {
-  display: flex;            
-  align-items: center;      
-  white-space: nowrap;      
-  overflow: hidden;         
-
-  > span {
-      overflow: hidden;         
-      text-overflow: ellipsis;  
-      max-width: 90%;           
-  }
-
-  img {
-      margin-right: 10px;
-      vertical-align: text-top;
-  }
-}
-
 .Post-header {
   .item-country {
     img {
       vertical-align: text-top;
     }
-  }
-}
-
-.Modal #geoip-map {
-  height: 300px;
-  resize: vertical;
-  overflow: hidden;
-}
-
-.MapModal {
-  .IPSubtitle {
-    font-size: 1em;
-    font-weight: normal;
-    color: var(--muted-color);
-    margin-top: -10px;
-    margin-bottom: 20px;
-  }
-
-  .IPDetails {
-    margin-bottom: 15px;
-    padding: 10px;
-    border: 1px solid var(--muted-color);
-    border-radius: @border-radius;
-    background-color: var(--control-bg);
-
-    h3 {
-      font-size: 1.25em;
-      margin-top: 0;
-      margin-bottom: 10px;
-      color: @primary-color;
-    }
-
-    p {
-      margin: 5px 0;
-      color: var(--text-color);
-    }
-  }
-
-  .clickable-ip:hover {
-    text-decoration: underline;
-    cursor: pointer;
-  }
-
-  #mapContainer {
-    margin-top: 10px;
-    border: 1px solid var(--muted-color);
-    border-radius: @border-radius;
   }
 }

--- a/resources/locale/en.yml
+++ b/resources/locale/en.yml
@@ -70,7 +70,9 @@ fof-geoip:
       error_prefix: "Error:"
       error_code_prefix: "Code:"
 
-  forum:
+  # Keys shared between the forum and admin frontends. The `lib` namespace is
+  # shipped to every frontend by Flarum's AddTranslations::forFrontend filter.
+  lib:
     alerts:
       ip_copied: Copied IP Address
     copy_ip_label: Copy IP to clipboard
@@ -88,6 +90,8 @@ fof-geoip:
       threat_types: "Threat Types"
       error: "Error"
       not_enough_data: "Not enough data to draw a map"
+
+  forum:
     user:
       settings:
         ip_country: Show the flag of the country I post from, based on my IP address


### PR DESCRIPTION
Ports the 1.x admin `<IPAddress>` enhancement (PR #85) to 2.x, so the admin Users list gets the country flag, copy-to-clipboard button, and `MapModal` IP info — previously these only ran on the forum frontend.

## Changes

- **Admin entry calls the extender** — `extendIpAddress()` (already in `common/`) is now called from `js/src/admin/index.ts`.
- **Shared translations** — moved the keys used by both frontends (`copy_ip_label`, `map_button_label`, `alerts.ip_copied`, `map_modal.*`) into a `lib:` namespace in `resources/locale/en.yml`. Flarum's `AddTranslations::forFrontend` regex ships `lib` keys to every frontend; keys under `forum:` are never sent to admin. Updated the `trans()` calls in `common/**` accordingly (including `ZipCodeMap`'s `not_enough_data`). The forum-only `forum.user.settings.ip_country` key stays under `forum:`.
- **Shared styles** — extracted the genuinely shared rules (`.ip-container`, `.Modal #geoip-map`, `.MapModal`) into `resources/less/common.less`, imported by both `forum.less` and `admin.less`, and added the leaflet stylesheet import to `admin.less` since the admin side now opens `MapModal`.

### Note on threat-level colours

The original issue suggested moving the `data-threat-level` colours into the shared file. These are scoped to forum-only selectors (`.PostMeta-ip` and the ban modal `code`) and `data-threat-level` is only set on the forum side, so they stay in `forum.less` rather than becoming dead CSS in admin.

Closes #86