### PR TITLE
[2.x] fix: TypeError when a post's author is unavailable

### DIFF
--- a/js/src/forum/extenders/extendCommentPost.tsx
+++ b/js/src/forum/extenders/extendCommentPost.tsx
@@ -14,8 +14,8 @@ export default function extendCommentPost() {
     // the admin feature is enabled. If the admin later disables it, the stored
     // preference is not serialized (see the customFlagCountry field visibility
     // in extend.php), so we fall back to today's IP-based behaviour.
-    if (app.forum.attribute<boolean>('fof-geoip.allowCustomFlag')) {
-      const customFlag = postUser?.customFlagCountry();
+    if (postUser && app.forum.attribute<boolean>('fof-geoip.allowCustomFlag')) {
+      const customFlag = postUser.customFlagCountry();
       if (customFlag) {
         // Custom flag is self-disclosed and therefore visible to everyone.
         const image = getFlagImageForCountry(customFlag);


### PR DESCRIPTION
## Problem

`Post::user()` returns `false` (not `null`) when the author relationship is absent — e.g. a deleted user. Optional chaining does not short-circuit on `false`, so:

```ts
const customFlag = postUser?.customFlagCountry();
```

evaluated `false.customFlagCountry()` and threw `TypeError: customFlagCountry is not a function` during `CommentPost` rendering for every post whose author is unavailable (with the custom-flag feature enabled). The error is caught by the extender wrapper, so the flag silently fails to render, but it throws on each such post.

## Fix

Guard the custom-flag branch with a truthiness check on the post author rather than optional chaining, so `false` (and `null`/`undefined`) are all handled. The IP-based branch below already uses `postUser &&`.

## Notes

Confirmed in-browser: on a discussion containing posts by deleted users, the console error is gone after this change. Not caught by existing tests because it is a frontend runtime error (the extension has no JS test suite, and TypeScript does not flag `false?.method()`).