### PR TITLE
[2.x] fix: Batch ip_info loading to avoid per-post queries during serialization

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -63,43 +63,70 @@ return [
 
                     // Full IP info for users with viewIps permission
                     if ($actor->can('viewIps', $post)) {
-                        return true;
+                        $visible = true;
+                    } elseif ($actor->can('fof-geoip.canSeeCountry')) {
+                        // Basic country info for users with the canSeeCountry permission.
+                        $visible = true;
+                    } elseif (!resolve(SettingsRepositoryInterface::class)->get('fof-geoip.showFlag')) {
+                        // ...or, when the showFlag feature is enabled, if the post's
+                        // author opted in via their showIPCountry preference.
+                        //
+                        // Evaluated last and short-circuited so the author preference
+                        // is only consulted when it is actually decisive (showFlag on,
+                        // and the actor lacks the broader permissions above). This
+                        // preserves the original decision
+                        // `viewCountry || (showFlag && authorPref)` exactly.
+                        $visible = false;
+                    } else {
+                        // Resolve the author preference via the memoizing resolver
+                        // rather than $post->user, which would lazy-load one user per
+                        // post during serialization (firstPost, lastPost, and every
+                        // post in a stream) — an N+1 on the hottest endpoints. We read
+                        // user_id off the post directly (a loaded column, no relation
+                        // load) and let the request-scoped resolver batch/cache.
+                        $visible = (bool) resolve(Repositories\AuthorFlagPreferenceResolver::class)
+                            ->wantsFlag($post->user_id);
                     }
 
-                    // Basic country info for users with the canSeeCountry permission.
-                    if ($actor->can('fof-geoip.canSeeCountry')) {
-                        return true;
+                    // Self-heal missing lookups: when the (eager-loaded) relation
+                    // shows this post has no stored ip_info, queue a retrieval.
+                    // This replaces the relationship's previous withDefault, whose
+                    // closure Laravel invoked once per post BEFORE the batched
+                    // relation query even ran — one wasted query per post on every
+                    // list. Here the miss is only observed on the loaded relation.
+                    if ($visible && $post->ip_address && $post->relationLoaded('ip_info') && !$post->getRelation('ip_info')) {
+                        $info = resolve(Repositories\GeoIPRepository::class)->queueLookupForPost($post);
+
+                        // With the sync queue driver the lookup already ran, so
+                        // serialize the fresh data right away.
+                        if ($info) {
+                            $post->setRelation('ip_info', $info);
+                        }
                     }
 
-                    // ...or, when the showFlag feature is enabled, if the post's
-                    // author opted in via their showIPCountry preference.
-                    //
-                    // Evaluated last and short-circuited so the author preference
-                    // is only consulted when it is actually decisive (showFlag on,
-                    // and the actor lacks the broader permissions above). This
-                    // preserves the original decision
-                    // `viewCountry || (showFlag && authorPref)` exactly.
-                    if (!resolve(SettingsRepositoryInterface::class)->get('fof-geoip.showFlag')) {
-                        return false;
-                    }
-
-                    // Resolve the author preference via the memoizing resolver
-                    // rather than $post->user, which would lazy-load one user per
-                    // post during serialization (firstPost, lastPost, and every
-                    // post in a stream) — an N+1 on the hottest endpoints. We read
-                    // user_id off the post directly (a loaded column, no relation
-                    // load) and let the request-scoped resolver batch/cache.
-                    return resolve(Repositories\AuthorFlagPreferenceResolver::class)
-                        ->wantsFlag($post->user_id);
+                    return $visible;
                 }),
         ])
         ->endpoint(['show', 'index', 'update'], function (Endpoint\Show|Endpoint\Index|Endpoint\Update $endpoint): Endpoint\Show|Endpoint\Index|Endpoint\Update {
-            return $endpoint->addDefaultInclude(['ipInfo']);
+            // Eager load the relation alongside the posts: included to-one
+            // relations are otherwise resolved one post at a time during
+            // serialization — one ip_info query per post on the post stream.
+            return $endpoint
+                ->addDefaultInclude(['ipInfo'])
+                ->eagerLoad(['ip_info']);
         }),
 
     (new Extend\ApiResource(Resource\DiscussionResource::class))
         ->endpoint(['show', 'index'], function (Endpoint\Show|Endpoint\Index $endpoint): Endpoint\Show|Endpoint\Index {
-            return $endpoint->addDefaultInclude(['firstPost.ipInfo']);
+            // Same as above, for the posts included on discussion endpoints:
+            // one batched ip_info load per relation path instead of one query
+            // per included post.
+            return $endpoint
+                ->addDefaultInclude(['firstPost.ipInfo'])
+                ->eagerLoadWhenIncluded([
+                    'firstPost' => ['firstPost.ip_info'],
+                    'lastPost'  => ['lastPost.ip_info'],
+                ]);
         }),
 
     (new Extend\ApiResource(Resource\ForumResource::class))

--- a/src/Model/IPInfoRelationship.php
+++ b/src/Model/IPInfoRelationship.php
@@ -12,20 +12,17 @@
 namespace FoF\GeoIP\Model;
 
 use Flarum\Post\Post;
-use FoF\GeoIP\Repositories\GeoIPRepository;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class IPInfoRelationship
 {
-    public function __construct(protected GeoIPRepository $geoIP)
-    {
-    }
-
     public function __invoke(Post $post): HasOne
     {
-        return $post->hasOne(IPInfo::class, 'address', 'ip_address')
-            ->withDefault(function (IPInfo $instance, Post $submodel) {
-                return $this->geoIP->retrieveForPost($submodel);
-            });
+        // No withDefault here: Laravel's eager loading calls getDefaultFor()
+        // for every parent BEFORE the batched relation query runs, so a
+        // default closure that looks anything up executes once per post on
+        // every list. Missing lookups are queued at serialization time
+        // instead, where a genuine miss is observable (see extend.php).
+        return $post->hasOne(IPInfo::class, 'address', 'ip_address');
     }
 }

--- a/src/Repositories/GeoIPRepository.php
+++ b/src/Repositories/GeoIPRepository.php
@@ -41,23 +41,27 @@ class GeoIPRepository
     }
 
     /**
-     * @param Post $post
+     * Queue a lookup for a post whose ip_info is known to be missing.
      *
-     * @return IPInfo|void
+     * Unlike the old retrieveForPost(), this never queries the database —
+     * callers are expected to have already observed the miss on the loaded
+     * relation. Returns the freshly retrieved info when the (sync) queue
+     * driver executed the job immediately.
      */
-    public function retrieveForPost(Post $post)
+    public function queueLookupForPost(Post $post): ?IPInfo
     {
         $ip = $post->ip_address;
-        $info = $this->get($ip);
 
-        // Return the info or null. If we're already retrieving this IP, we don't want to queue it again
-        if ($info || !$ip || RetrieveIP::isQueued($ip)) {
-            return $info;
+        if (!$ip) {
+            return null;
         }
 
-        $this->queue->push(new RetrieveIP($ip));
+        // If we're already retrieving this IP, we don't want to queue it again.
+        if (!RetrieveIP::isQueued($ip)) {
+            $this->queue->push(new RetrieveIP($ip));
+        }
 
-        // If using the sync queue driver (default), the job will be executed immediately
+        // If using the sync queue driver (default), the job has already run.
         return Arr::get(RetrieveIP::$retrieved, $ip);
     }
 

--- a/tests/integration/Api/IpInfoLoadQueryCountTest.php
+++ b/tests/integration/Api/IpInfoLoadQueryCountTest.php
@@ -1,0 +1,223 @@
+<?php
+
+/*
+ * This file is part of fof/geoip.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\GeoIP\Tests\integration\Api;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use FoF\GeoIP\Model\IPInfo;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Regression test for the per-post ip_info load.
+ *
+ * The ipInfo relationships of included posts were resolved one post at a
+ * time (core's deferred include resolution is depth-first), so a discussion
+ * list issued one `ip_info` query per included post, and the post stream one
+ * per post. Eager-loading the relation alongside the posts collapses this to
+ * one query per relation path, regardless of page size.
+ */
+class IpInfoLoadQueryCountTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    /** Number of discussions seeded for the list. */
+    private const DISCUSSION_COUNT = 15;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-geoip');
+
+        $users = [$this->normalUser()];
+        $discussions = [];
+        $posts = [];
+        $ipInfo = [];
+        $now = Carbon::now();
+
+        // Each discussion has a distinct firstPost and lastPost, each with its
+        // own IP address and a stored ip_info row — so a per-post load shows
+        // up as 2 × DISCUSSION_COUNT queries on the discussion list.
+        for ($i = 0; $i < self::DISCUSSION_COUNT; $i++) {
+            $discussionId = 100 + $i;
+            $firstPostId = 1000 + $i;
+            $lastPostId = 2000 + $i;
+            $firstIp = "10.1.0.$i";
+            $lastIp = "10.1.1.$i";
+
+            $discussions[] = [
+                'id'             => $discussionId,
+                'title'          => "Discussion $discussionId",
+                'slug'           => "discussion-$discussionId",
+                'created_at'     => $now->toDateTimeString(),
+                'last_posted_at' => $now->copy()->addSeconds($i)->toDateTimeString(),
+                'user_id'        => 2,
+                'first_post_id'  => $firstPostId,
+                'last_post_id'   => $lastPostId,
+                'comment_count'  => 2,
+            ];
+            $posts[] = [
+                'id'            => $firstPostId,
+                'discussion_id' => $discussionId,
+                'number'        => 1,
+                'created_at'    => $now->toDateTimeString(),
+                'user_id'       => 2,
+                'type'          => 'comment',
+                'content'       => '<t><p>first</p></t>',
+                'ip_address'    => $firstIp,
+            ];
+            $posts[] = [
+                'id'            => $lastPostId,
+                'discussion_id' => $discussionId,
+                'number'        => 2,
+                'created_at'    => $now->copy()->addSeconds($i)->toDateTimeString(),
+                'user_id'       => 2,
+                'type'          => 'comment',
+                'content'       => '<t><p>last</p></t>',
+                'ip_address'    => $lastIp,
+            ];
+            $ipInfo[] = [
+                'address'      => $firstIp,
+                'country_code' => 'DE',
+                'created_at'   => $now->toDateTimeString(),
+                'updated_at'   => $now->toDateTimeString(),
+            ];
+            $ipInfo[] = [
+                'address'      => $lastIp,
+                'country_code' => 'FR',
+                'created_at'   => $now->toDateTimeString(),
+                'updated_at'   => $now->toDateTimeString(),
+            ];
+        }
+
+        $this->prepareDatabase([
+            User::class       => $users,
+            Discussion::class => $discussions,
+            Post::class       => $posts,
+            IPInfo::class     => $ipInfo,
+        ]);
+    }
+
+    private function countIpInfoQueries(array $log): int
+    {
+        return count(array_filter(
+            $log,
+            fn (array $q) => stripos($q['query'], 'ip_info') !== false
+        ));
+    }
+
+    #[Test]
+    public function discussion_list_loads_ip_info_once_per_relation_path_not_per_post()
+    {
+        $this->app();
+
+        $db = $this->database();
+        $db->flushQueryLog();
+        $db->enableQueryLog();
+
+        // Actor 1 (admin) passes the viewIps visibility check for every post.
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', ['authenticatedAs' => 1])
+                ->withQueryParams(['include' => 'firstPost,firstPost.ipInfo,lastPost,lastPost.ipInfo'])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $queries = $this->countIpInfoQueries($db->getQueryLog());
+        $db->flushQueryLog();
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        // Sanity: ip_info resources actually serialized for the included posts.
+        $included = collect($body['included'] ?? [])->where('type', 'ip_info');
+        $this->assertGreaterThanOrEqual(2 * self::DISCUSSION_COUNT, $included->count());
+
+        // One eager load per relation path (firstPost.ip_info, lastPost.ip_info)
+        // — must not scale with the number of discussions.
+        $this->assertSame(
+            2,
+            $queries,
+            "Discussion list issued $queries ip_info queries for ".self::DISCUSSION_COUNT.
+            ' discussions — ip_info must be eager-loaded per relation path, not loaded once per included post.'
+        );
+    }
+
+    #[Test]
+    public function post_stream_loads_ip_info_once_not_per_post()
+    {
+        $this->app();
+
+        $db = $this->database();
+        $db->flushQueryLog();
+        $db->enableQueryLog();
+
+        $response = $this->send(
+            $this->request('GET', '/api/posts', ['authenticatedAs' => 1])
+                ->withQueryParams(['filter' => ['discussion' => 100]])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $queries = $this->countIpInfoQueries($db->getQueryLog());
+        $db->flushQueryLog();
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        // Sanity: the ipInfo include is on by default and serialized.
+        $included = collect($body['included'] ?? [])->where('type', 'ip_info');
+        $this->assertGreaterThanOrEqual(2, $included->count());
+
+        $this->assertSame(
+            1,
+            $queries,
+            "Post stream issued $queries ip_info queries — ip_info must be eager-loaded with the posts in one query."
+        );
+    }
+
+    /**
+     * The relationship's withDefault used to trigger lookups for missing
+     * ip_info rows; that moved to serialization time, where the miss is
+     * observed on the eager-loaded relation. This pins that a post with no
+     * stored ip_info still gets a retrieval queued when it is serialized to
+     * an actor who can see IP info.
+     */
+    #[Test]
+    public function missing_ip_info_rows_still_queue_a_lookup_when_serialized()
+    {
+        $this->app();
+
+        $missingIp = '10.1.0.0'; // firstPost of discussion 100
+        $this->database()->table('ip_info')->where('address', $missingIp)->delete();
+
+        // Prime the job's "already retrieving" cache guard so the (sync) job
+        // exits before calling the external geoip service; the queue push and
+        // its bookkeeping still happen.
+        $this->app()->getContainer()->make('cache.store')->add("fof-geoip.retrieving.$missingIp", true, 60);
+
+        $response = $this->send(
+            $this->request('GET', '/api/posts', ['authenticatedAs' => 1])
+                ->withQueryParams(['filter' => ['discussion' => 100]])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $this->assertContains(
+            $missingIp,
+            \FoF\GeoIP\Jobs\RetrieveIP::$queued,
+            'Serializing a post with no stored ip_info must queue a lookup for its IP.'
+        );
+    }
+}


### PR DESCRIPTION
## Problem

Every serialized post cost one `ip_info` query for actors who can see IP data: 20 per discussion list, one per post on the post stream. Backtracing showed two compounding mechanisms:

1. **Per-post include resolution**: included to-one relations are resolved one post at a time during document building, so `firstPost.ipInfo` / `ipInfo` loaded individually per post.
2. **`withDefault` on the relation**: Laravel's eager loading calls `getDefaultFor()` for **every parent before the batched relation query runs**, and the default closure ran a `getSaved()` DB lookup each time. This alone made the relation impossible to batch — endpoint eager loads only halved the count until it was removed.

## Fix

- The discussion endpoints eager load `firstPost.ip_info` / `lastPost.ip_info` when those posts are included, and the post endpoints eager load `ip_info` — mirroring core's mentions extension (`mentionsTags`). One batched query per relation path, regardless of page size.
- `withDefault` is removed from the relationship. The "retrieve missing IPs on view" behaviour moves to serialization time, where a genuine miss is observable on the loaded relation: a new `GeoIPRepository::queueLookupForPost()` queues the `RetrieveIP` job (never queries the DB itself). Queue semantics are unchanged on sync and async (redis/horizon/database) drivers, and on the sync driver freshly retrieved info still serializes in the same request.
- Side-effect fix: posts without stored ip_info no longer serialize linkage to empty `withDefault` placeholder models — only real rows are linked.

## Measured

- Integration tests: discussion list with 15 discussions × 2 posts: **60 → 2** ip_info queries; post stream: **3 → 1**.
- Real forum, admin actor, `/api/discussions?page[limit]=20`: total request queries **62 → 43**, with payload verified (only genuine ip_info rows serialize).

## Tests

New `IpInfoLoadQueryCountTest`: pins one batched load per relation path on both endpoints, and that a post with a missing ip_info row still queues a `RetrieveIP` lookup when serialized (the job's cache guard is primed in the test so no external call happens).

## Deployment note

Restart queue workers (horizon) after updating so they pick up the changed job/repository code.

Part of the same query-count effort as flarum/framework#4839, FriendsOfFlarum/terms#85, FriendsOfFlarum/moderator-warnings#7, and FriendsOfFlarum/moderator-notes#45.