### PR TITLE
[2.x] fix: restore batched author preference lookups in ip_info visibility

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -81,11 +81,12 @@ return [
                         // Resolve the author preference via the memoizing resolver
                         // rather than $post->user, which would lazy-load one user per
                         // post during serialization (firstPost, lastPost, and every
-                        // post in a stream) — an N+1 on the hottest endpoints. We read
-                        // user_id off the post directly (a loaded column, no relation
-                        // load) and let the request-scoped resolver batch/cache.
+                        // post in a stream) — an N+1 on the hottest endpoints. The
+                        // resolver reads the post's eager-loaded `user` relation when
+                        // present (no query), and only falls back to a lookup for a
+                        // post whose author was not loaded alongside it.
                         $visible = (bool) resolve(Repositories\AuthorFlagPreferenceResolver::class)
-                            ->wantsFlag($post->user_id);
+                            ->wantsFlagFor($post);
                     }
 
                     // Self-heal missing lookups: when the (eager-loaded) relation
@@ -121,12 +122,28 @@ return [
             // Same as above, for the posts included on discussion endpoints:
             // one batched ip_info load per relation path instead of one query
             // per included post.
-            return $endpoint
+            $endpoint = $endpoint
                 ->addDefaultInclude(['firstPost.ipInfo'])
                 ->eagerLoadWhenIncluded([
                     'firstPost' => ['firstPost.ip_info'],
                     'lastPost'  => ['lastPost.ip_info'],
                 ]);
+
+            // When the showFlag feature is on, the ip_info visibility check
+            // needs each post author's showIPCountry preference. Load the
+            // authors alongside the posts so the resolver reads them without
+            // a query — otherwise it falls back to one lookup per distinct
+            // author. Gated on the setting because with the flag off the
+            // visibility decision never consults the author at all, and the
+            // extra relation would be a wasted query.
+            if ((bool) resolve(SettingsRepositoryInterface::class)->get('fof-geoip.showFlag')) {
+                $endpoint = $endpoint->eagerLoadWhenIncluded([
+                    'firstPost' => ['firstPost.user'],
+                    'lastPost'  => ['lastPost.user'],
+                ]);
+            }
+
+            return $endpoint;
         }),
 
     (new Extend\ApiResource(Resource\ForumResource::class))

--- a/src/Repositories/AuthorFlagPreferenceResolver.php
+++ b/src/Repositories/AuthorFlagPreferenceResolver.php
@@ -11,6 +11,7 @@
 
 namespace FoF\GeoIP\Repositories;
 
+use Flarum\Post\Post;
 use Flarum\User\User;
 
 /**
@@ -32,6 +33,33 @@ class AuthorFlagPreferenceResolver
 {
     /** @var array<int, bool> userId => showIPCountry */
     protected array $cache = [];
+
+    /**
+     * Resolve the preference for a post's author, preferring the post's
+     * already eager-loaded `user` relation — reading it costs no query at
+     * all. Endpoints that serialize many posts eager load their authors
+     * (core does for the post stream, our extender does for the posts
+     * included on discussion lists), so this is the hot path; the id-based
+     * lookup below is only the fallback for a post whose author was not
+     * loaded alongside it.
+     */
+    public function wantsFlagFor(Post $post): bool
+    {
+        $userId = $post->user_id;
+
+        if ($userId === null) {
+            return false;
+        }
+
+        if (!array_key_exists($userId, $this->cache) && $post->relationLoaded('user')) {
+            /** @var User|null $user */
+            $user = $post->getRelation('user');
+
+            $this->cache[$userId] = $user !== null && (bool) $user->getPreference('showIPCountry');
+        }
+
+        return $this->wantsFlag($userId);
+    }
 
     public function wantsFlag(?int $userId): bool
     {


### PR DESCRIPTION
## The regression

The memoizing `AuthorFlagPreferenceResolver` from #93 survived the #100 restructure but lost the thing that made it batch: nothing loads the post authors ahead of it any more. With `showFlag` enabled, every distinct author costs one preference query during serialization:

```
30x (30 distinct bindings): select * from "users" where "id" in (?)
```

That's the exact N+1 #93 fixed, back at HEAD. Caught twice independently: by #93's own guard test (`IpInfoListQueryCountTest`), and by the query guard in flarum/testing 2.x-dev, which fails the suite on its own.

## The fix

Two parts:

**The resolver prefers the post's eager-loaded `user` relation** (`wantsFlagFor(Post $post)`) — reading it costs no query at all — and only falls back to the id-based lookup for a post whose author wasn't loaded alongside it. The post stream needs nothing further: core already eager loads post authors there, so that path is free by construction.

**The discussion endpoints eager load `firstPost.user` / `lastPost.user`** whenever those posts are included, gated on the `showFlag` setting. With the flag off, the visibility decision short-circuits before ever consulting the author, so flag-off installs load nothing extra — covered by the existing `listing_discussions_with_showflag_off_does_not_touch_authors_per_post` test.

## Measured (same request: 15 discussions, firstPost+lastPost included, 30 distinct authors, showFlag on)

| | before | after |
|---|---|---|
| total queries | 76 | **48** |
| author preference fetches | 30 singles | **2 batched `whereIn`** |

One trade-off worth noting: an actor with `viewIps` or `canSeeCountry` short-circuits visibility without consulting author preferences, but still pays the 2 batched loads on flag-on forums — the extender API can gate an eager load on a setting but not on the actor. Two bounded queries versus 30+ unbounded singles seemed like the right side of that trade.

## Not fixed here, deliberately

The query guard still reports one repeated shape: `30x (15 distinct): select * from "discussions" where "discussions"."id" = ?` — included first/last posts are materialised by core without their `discussion` relation, so `PostPolicy` lazy-loads it per instance while serializing `canEdit`/`canHide`/`canFlag`. Any extension that includes `firstPost` triggers this (flarum/sticky does it on every install), so the fix belongs in core; it's on my list there.

## Testing

- Guard test RED at HEAD → GREEN with the fix; full suite 65/65
- Flag-off path covered by the existing dedicated test
- PHPStan clean