### PR TITLE
[2.x] perf: stop default-including firstPost.ipInfo on discussion endpoints

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -119,11 +119,13 @@ return [
 
     (new Extend\ApiResource(Resource\DiscussionResource::class))
         ->endpoint(['show', 'index'], function (Endpoint\Show|Endpoint\Index $endpoint): Endpoint\Show|Endpoint\Index {
-            // Same as above, for the posts included on discussion endpoints:
-            // one batched ip_info load per relation path instead of one query
-            // per included post.
+            // Batched loads for clients that explicitly include post
+            // relations on discussion endpoints. No default include: nothing
+            // on the discussion list displays ip_info (flags render in the
+            // post stream, fed by the posts endpoint), and default-including
+            // firstPost.ipInfo forced every first post to be fully serialized
+            // — rendered HTML and per-post policies — on every index view.
             $endpoint = $endpoint
-                ->addDefaultInclude(['firstPost.ipInfo'])
                 ->eagerLoadWhenIncluded([
                     'firstPost' => ['firstPost.ip_info'],
                     'lastPost'  => ['lastPost.ip_info'],

--- a/tests/integration/Api/DiscussionIndexDefaultPayloadTest.php
+++ b/tests/integration/Api/DiscussionIndexDefaultPayloadTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of fof/geoip.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\GeoIP\Tests\integration\Api;
+
+use Carbon\Carbon;
+use Flarum\Discussion\Discussion;
+use Flarum\Post\Post;
+use Flarum\Testing\integration\RetrievesAuthorizedUsers;
+use Flarum\Testing\integration\TestCase;
+use Flarum\User\User;
+use FoF\GeoIP\Model\IPInfo;
+use PHPUnit\Framework\Attributes\Test;
+
+class DiscussionIndexDefaultPayloadTest extends TestCase
+{
+    use RetrievesAuthorizedUsers;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->extension('fof-geoip');
+
+        $now = Carbon::now();
+
+        $this->prepareDatabase([
+            User::class => [
+                $this->normalUser(),
+            ],
+            Discussion::class => [
+                ['id' => 1, 'title' => 'One', 'created_at' => $now, 'last_posted_at' => $now, 'user_id' => 1, 'first_post_id' => 1, 'comment_count' => 1],
+                ['id' => 2, 'title' => 'Two', 'created_at' => $now, 'last_posted_at' => $now, 'user_id' => 1, 'first_post_id' => 2, 'comment_count' => 1],
+            ],
+            Post::class => [
+                ['id' => 1, 'discussion_id' => 1, 'created_at' => $now, 'user_id' => 1, 'type' => 'comment', 'number' => 1, 'content' => '<t><p>first</p></t>', 'ip_address' => '10.0.0.1'],
+                ['id' => 2, 'discussion_id' => 2, 'created_at' => $now, 'user_id' => 1, 'type' => 'comment', 'number' => 1, 'content' => '<t><p>second</p></t>', 'ip_address' => '10.0.0.2'],
+            ],
+            IPInfo::class => [
+                ['address' => '10.0.0.1', 'country_code' => 'DE', 'created_at' => $now->toDateTimeString(), 'updated_at' => $now->toDateTimeString()],
+                ['address' => '10.0.0.2', 'country_code' => 'FR', 'created_at' => $now->toDateTimeString(), 'updated_at' => $now->toDateTimeString()],
+            ],
+        ]);
+    }
+
+    protected function includedOfType(array $body, string $type): array
+    {
+        return array_values(array_filter($body['included'] ?? [], fn (array $r) => $r['type'] === $type));
+    }
+
+    #[Test]
+    public function the_discussions_index_serializes_no_posts_by_default(): void
+    {
+        // Nothing on the discussion list displays ip_info — flags render in
+        // the post stream, which gets its data from the posts endpoint.
+        // Default-including firstPost.ipInfo forced every first post to be
+        // fully serialized (rendered HTML, per-post policies) on every index
+        // view, for data no list client reads.
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', ['authenticatedAs' => 1])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertCount(0, $this->includedOfType($body, 'posts'), 'The index must not serialize posts by default.');
+        $this->assertCount(0, $this->includedOfType($body, 'ip_info'), 'The index must not serialize ip_info by default.');
+    }
+
+    #[Test]
+    public function explicitly_including_first_post_ip_info_still_works(): void
+    {
+        // Clients that want the data (moderation tools, API consumers) can
+        // still ask for it, and the batched eager loads still apply.
+        $response = $this->send(
+            $this->request('GET', '/api/discussions', ['authenticatedAs' => 1])
+                ->withQueryParams(['include' => 'firstPost,firstPost.ipInfo'])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $body = json_decode($response->getBody()->getContents(), true);
+
+        $this->assertCount(2, $this->includedOfType($body, 'posts'));
+        $this->assertCount(2, $this->includedOfType($body, 'ip_info'));
+    }
+}


### PR DESCRIPTION
Part of the discussions-index cleanup after flarum/framework#4882 (sticky) and FriendsOfFlarum/synopsis#5: geoip was one of the extensions forcing `firstPost` into every index payload.

## The problem

`addDefaultInclude(['firstPost.ipInfo'])` on the discussion endpoints doesn't just batch a relation — in JSON:API, including a nested path includes **every resource along it**. So every index view fully serialized every first post (rendered HTML through every extension's render callbacks, per-post visibility policies, full content in the payload) to carry ip_info that **no list client reads**: flags render in the post stream (fed by the posts endpoint's own default include), the ban modal fetches on demand, and profile post streams add the include client-side.

## The change

Drop the default include; keep everything else. The `eagerLoadWhenIncluded` batching (#100) and the setting-gated author preloads (#105) remain, so clients that explicitly include the relations — moderation tools, API consumers — keep both the data and the batching.

## Testing

New `DiscussionIndexDefaultPayloadTest`, RED first against current code:

- the default index serializes **no posts and no ip_info** (was: both)
- an explicit `include=firstPost,firstPost.ipInfo` still serializes and batches both — the contract for clients that want the data

Suite 67/67, PHPStan clean.

One note from writing the tests: ip_info's visibility gate means it only serializes for actors passing `viewIps`/`canSeeCountry`/showFlag — the tests authenticate as admin accordingly.